### PR TITLE
Replace com.gradle.enterprise with com.gradle.develocity

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -11,7 +11,7 @@ pluginManagement {
 
 plugins {
 	id("net.twisterrob.gradle.plugin.settings") version "0.16"
-	id("com.gradle.enterprise") version "3.17"
+	id("com.gradle.develocity") version "3.17"
 	id("org.gradle.toolchains.foojay-resolver-convention") version "0.8.0"
 }
 
@@ -66,9 +66,9 @@ includeBuild("libs") { build ->
 	apply from: new File(build.projectDir, "gradle/settings.substitutions.gradle"), to: build
 }
 
-gradleEnterprise {
+develocity {
 	buildScan {
-		termsOfServiceUrl = "https://gradle.com/terms-of-service"
-		termsOfServiceAgree = "yes"
+		termsOfUseUrl = "https://gradle.com/help/legal-terms-of-use"
+		termsOfUseAgree = "yes"
 	}
 }


### PR DESCRIPTION
```
WARNING: The following functionality has been deprecated and will be removed in the next major release of the Develocity Gradle plugin:
- The deprecated "gradleEnterprise.buildScan.termsOfServiceUrl" API has been replaced by "develocity.buildScan.termsOfUseUrl"
- The deprecated "gradleEnterprise.buildScan.termsOfServiceAgree" API has been replaced by "develocity.buildScan.termsOfUseAgree"
- The "com.gradle.enterprise" plugin has been replaced by "com.gradle.develocity"
```