### PR TITLE
Fix broken link

### DIFF
--- a/android/feature/range/src/main/res/values/strings.xml
+++ b/android/feature/range/src/main/res/values/strings.xml
@@ -94,7 +94,7 @@
 	(<i>measured in minutes</i>)
 	This only applies within a single station, without going to the street.
 	It may range from a few seconds to several minutes, depending on the station size:
-	<a href="http://www.cityam.com/226215/longest-tube-interchange-10-tube-stations-where-changing-lines-takes-longest">
+	<a href="https://www.cityam.com/226215/longest-tube-interchange-10-tube-stations-where-changing-lines-takes-longest">
 		for example interchanges at Bank, Charing Cross, Kings Cross will take over a 5 minute walk</a>.
 	]]></string>
 

--- a/android/feature/range/src/main/res/values/strings.xml
+++ b/android/feature/range/src/main/res/values/strings.xml
@@ -53,7 +53,7 @@
 			line="Metropolitan">Great Portland Street</station></li>
 		<li><station line="Circle">Farringdon</station>⇌<station line="Central">Chancery Lane</station></li>
 	</ul>
-	<a href="https://web.archive.org/web/20160731081313/https://tfl.gov.uk/fares-and-payments/oyster/using-oyster/touching-in-and-out#on-this-page-5">
+	<a href="https://tfl.gov.uk/fares/how-to-pay-and-where-to-buy-tickets-and-oyster/pay-as-you-go/touching-in-and-out">
 		TfL will likely count these as fully leaving/entering the system</a>.
 	\nThere are some stations where you can make an interchange and TfL may count it as an intra-station interchange;
 	examples of this:

--- a/android/feature/range/src/main/res/values/strings.xml
+++ b/android/feature/range/src/main/res/values/strings.xml
@@ -53,7 +53,7 @@
 			line="Metropolitan">Great Portland Street</station></li>
 		<li><station line="Circle">Farringdon</station>⇌<station line="Central">Chancery Lane</station></li>
 	</ul>
-	<a href="https://tfl.gov.uk/fares-and-payments/oyster/using-oyster/touching-in-and-out#on-this-page-5">
+	<a href="https://web.archive.org/web/20160731081313/https://tfl.gov.uk/fares-and-payments/oyster/using-oyster/touching-in-and-out#on-this-page-5">
 		TfL will likely count these as fully leaving/entering the system</a>.
 	\nThere are some stations where you can make an interchange and TfL may count it as an intra-station interchange;
 	examples of this:


### PR DESCRIPTION
The original link was pointing here:

https://web.archive.org/web/20160731081313/https://tfl.gov.uk/fares-and-payments/oyster/using-oyster/touching-in-and-out#on-this-page-5

![image](https://github.com/TWiStErRob/net.twisterrob.travel/assets/2906988/9d7ebf95-d3a5-4b3d-91d4-5677b91b72ed)

I'm not sure where exactly I was pointing so I linked to the closest thing about touching rules:

https://tfl.gov.uk/fares/how-to-pay-and-where-to-buy-tickets-and-oyster/pay-as-you-go/touching-in-and-out