### PR TITLE
Add TubeDepartureBoardsStationStatusIncidents to Feed so cron can run

### DIFF
--- a/docs/release.md
+++ b/docs/release.md
@@ -6,7 +6,7 @@
 1. `gradlew :web:status-history:appengineDeploy :web:status-history:appengineDeployCron`
 1. Verify new version is created in [Google Cloud Console][versions].
 1. Check [live][live] version is operational.
-1. `git tag -f live` on `main` and `git push -f live`.
+1. `git tag -f live` on `main` and `git push origin -f live`.
 1. Clean up old versions in [Google Cloud Console][versions].
 
 [live]: https://twisterrob-london.appspot.com/

--- a/docs/release.md
+++ b/docs/release.md
@@ -3,7 +3,7 @@
 0. Check [live][live] version is operational.
 1. Ensure latest `main` in git clone.
 1. Change `testDeployment` to `false` in `web/status-history/build.gradle.kts`.
-1. `gradlew :web:status-history:appengineDeploy`
+1. `gradlew :web:status-history:appengineDeploy :web:status-history:appengineDeployCron`
 1. Verify new version is created in [Google Cloud Console][versions].
 1. Check [live][live] version is operational.
 1. `git tag -f live` on `main` and `git push -f live`.

--- a/domain/status/src/commonMain/kotlin/net/twisterrob/travel/domain/london/status/Feed.kt
+++ b/domain/status/src/commonMain/kotlin/net/twisterrob/travel/domain/london/status/Feed.kt
@@ -3,4 +3,5 @@ package net.twisterrob.travel.domain.london.status
 enum class Feed {
 	TubeDepartureBoardsLineStatus,
 	TubeDepartureBoardsLineStatusIncidents,
+	TubeDepartureBoardsStationStatusIncidents,
 }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/34ce56c4-f622-45c9-9ab7-caa3fdccb6b0)

```
{
	"_links": {
		"self": [
			{
				"href": "[/refresh?feed=TubeDepartureBoardsStationStatusIncidents](http://localhost:8080/refresh?feed=TubeDepartureBoardsStationStatusIncidents)",
				"templated": false
			}
		]
	},
	"_embedded": {
		"errors": [
			{
				"message": "Failed to convert argument [feed] for value [TubeDepartureBoardsStationStatusIncidents] due to: No enum constant net.twisterrob.travel.domain.london.status.Feed.TubeDepartureBoardsStationStatusIncidents",
				"path": "[/feed](http://localhost:8080/feed)"
			}
		]
	},
	"message": "Bad Request"
}
```