### PR TITLE
Enable KSP 2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,6 +6,3 @@ org.gradle.configuration-cache=true
 org.gradle.configuration-cache.problems=fail
 
 android.useAndroidX=true
-
-# TODEL once https://github.com/micronaut-projects/micronaut-core/issues/11553 resolved.
-ksp.useKSP2=false


### PR DESCRIPTION
> \> Configure project :web:status-history
> We noticed you are using KSP1 which is deprecated and support for it will be removed soon - please migrate to KSP2 as soon as possible. KSP1 will no longer be compatible with Android Gradle Plugin 9.0.0 (and above) and Kotlin 2.3.0 (and above)

https://github.com/micronaut-projects/micronaut-core/issues/11553 is fixed