### PR TITLE
Raise Android compileSdk from 35 to 36

### DIFF
--- a/gradle/plugins/src/main/groovy/net.twisterrob.travel.android-app.gradle
+++ b/gradle/plugins/src/main/groovy/net.twisterrob.travel.android-app.gradle
@@ -6,7 +6,7 @@ plugins {
 
 android {
 	namespace = "net.twisterrob.blt${project.path.replace(":", ".")}"
-	compileSdk = 37
+	compileSdk = 36
 	defaultConfig {
 		minSdk = 24
 		targetSdk = 34

--- a/gradle/plugins/src/main/groovy/net.twisterrob.travel.android-app.gradle
+++ b/gradle/plugins/src/main/groovy/net.twisterrob.travel.android-app.gradle
@@ -6,7 +6,7 @@ plugins {
 
 android {
 	namespace = "net.twisterrob.blt${project.path.replace(":", ".")}"
-	compileSdk = 35
+	compileSdk = 37
 	defaultConfig {
 		minSdk = 24
 		targetSdk = 34

--- a/gradle/plugins/src/main/groovy/net.twisterrob.travel.android-library.gradle
+++ b/gradle/plugins/src/main/groovy/net.twisterrob.travel.android-library.gradle
@@ -6,7 +6,7 @@ plugins {
 
 android {
 	namespace = "net.twisterrob.blt${project.path.replace(":", ".")}"
-	compileSdk = 35
+	compileSdk = 37
 	defaultConfig {
 		minSdk = 24
 	}

--- a/gradle/plugins/src/main/groovy/net.twisterrob.travel.android-library.gradle
+++ b/gradle/plugins/src/main/groovy/net.twisterrob.travel.android-library.gradle
@@ -6,7 +6,7 @@ plugins {
 
 android {
 	namespace = "net.twisterrob.blt${project.path.replace(":", ".")}"
-	compileSdk = 37
+	compileSdk = 36
 	defaultConfig {
 		minSdk = 24
 	}


### PR DESCRIPTION
## Summary

Raises the Android `compileSdk` from 35 to 36 in the shared Android library and application convention plugins.

This is the first step toward the compile SDK required by Glide 5.0.9. A follow-up PR will raise it from 36 to 37.

## Validation

CI will validate this change.