### PR TITLE
Raise Android compileSdk from 36 to 37

### DIFF
--- a/gradle/plugins/src/main/groovy/net.twisterrob.travel.android-app.gradle
+++ b/gradle/plugins/src/main/groovy/net.twisterrob.travel.android-app.gradle
@@ -6,7 +6,7 @@ plugins {
 
 android {
 	namespace = "net.twisterrob.blt${project.path.replace(":", ".")}"
-	compileSdk = 36
+	compileSdk = 37
 	defaultConfig {
 		minSdk = 24
 		targetSdk = 34

--- a/gradle/plugins/src/main/groovy/net.twisterrob.travel.android-app.gradle
+++ b/gradle/plugins/src/main/groovy/net.twisterrob.travel.android-app.gradle
@@ -6,7 +6,7 @@ plugins {
 
 android {
 	namespace = "net.twisterrob.blt${project.path.replace(":", ".")}"
-	compileSdk = 37
+	compileSdk = 36
 	defaultConfig {
 		minSdk = 24
 		targetSdk = 34

--- a/gradle/plugins/src/main/groovy/net.twisterrob.travel.android-app.gradle
+++ b/gradle/plugins/src/main/groovy/net.twisterrob.travel.android-app.gradle
@@ -6,7 +6,7 @@ plugins {
 
 android {
 	namespace = "net.twisterrob.blt${project.path.replace(":", ".")}"
-	compileSdk = 35
+	compileSdk = 37
 	defaultConfig {
 		minSdk = 24
 		targetSdk = 34

--- a/gradle/plugins/src/main/groovy/net.twisterrob.travel.android-library.gradle
+++ b/gradle/plugins/src/main/groovy/net.twisterrob.travel.android-library.gradle
@@ -6,7 +6,7 @@ plugins {
 
 android {
 	namespace = "net.twisterrob.blt${project.path.replace(":", ".")}"
-	compileSdk = 35
+	compileSdk = 37
 	defaultConfig {
 		minSdk = 24
 	}

--- a/gradle/plugins/src/main/groovy/net.twisterrob.travel.android-library.gradle
+++ b/gradle/plugins/src/main/groovy/net.twisterrob.travel.android-library.gradle
@@ -6,7 +6,7 @@ plugins {
 
 android {
 	namespace = "net.twisterrob.blt${project.path.replace(":", ".")}"
-	compileSdk = 36
+	compileSdk = 37
 	defaultConfig {
 		minSdk = 24
 	}

--- a/gradle/plugins/src/main/groovy/net.twisterrob.travel.android-library.gradle
+++ b/gradle/plugins/src/main/groovy/net.twisterrob.travel.android-library.gradle
@@ -6,7 +6,7 @@ plugins {
 
 android {
 	namespace = "net.twisterrob.blt${project.path.replace(":", ".")}"
-	compileSdk = 37
+	compileSdk = 36
 	defaultConfig {
 		minSdk = 24
 	}


### PR DESCRIPTION
## Summary

Stacked on #665, raises the Android `compileSdk` from 36 to 37 in the shared Android library and application convention plugins.

This completes the compile SDK prerequisite for Glide 5.0.9, which requires Android API 37 or newer.

## Validation

CI will validate this change.